### PR TITLE
[add, modify] props 수정, 이메일/닉네임 중복확인 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-### add, modify: 프로젝트 생성 페이지 틀 구성, 환경변수 추가, AuthType 변경
+### add, modify: props 수정, 이메일/닉네임 중복확인 구현
+
+#1 flexbox type, props에 $추가 <br>
+#2 input 폼 태그에서 엔터 시 바로 전송되는 기능 추가 <br>
+#3 탭 시 버튼이 아닌 다음 input, 버튼으로 넘어가도록 tabindex 추가
+
+- 로그인에는 이메일 비밀번호 제출버튼 순서 지정
+- 회원가입에는 remove, hide/visible 버튼만 순서 제외
+
+#4 onBlur 시 이메일/닉네임 중복확인 구현 <br>

--- a/src/page/Login/Login.tsx
+++ b/src/page/Login/Login.tsx
@@ -5,9 +5,9 @@ import { ReactComponent as PageIntro } from "../../assets/images/img.svg";
 
 const SignIn: React.FC = () => {
   return (
-    <S.LoginLayout justify="center" gap="144px">
-      <S.LoginIntroBox direction="column" gap="48px">
-        <S.LoginIntroText direction="column" gap="12px">
+    <S.LoginLayout $justify="center" $gap="144px">
+      <S.LoginIntroBox $direction="column" $gap="48px">
+        <S.LoginIntroText $direction="column" $gap="12px">
           <h1>
             모집과 협업을 한번에! <br />
             모두 있는 모임 공간

--- a/src/page/Login/LoginForms.tsx
+++ b/src/page/Login/LoginForms.tsx
@@ -54,21 +54,29 @@ export default function LoginForms() {
     }
   };
 
+  // 엔터 키 핸들링 함수
+  const handleKeyDown = (event: any) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      onLoginSubmit(event);
+    }
+  };
+
   // 버튼 상태 값
   let status = !isValidEmail(email) || !password ? "active" : "disable";
 
   return (
-    <S.LoginBox direction="column">
+    <S.LoginBox $direction="column">
       <nav>
         도움이 필요하세요? <Link to="">고객센터</Link>
       </nav>
       <S.LoginFormBox onSubmit={onLoginSubmit}>
         <h1>로그인</h1>
-        <S.LoginForm direction="column" gap="12px">
+        <S.LoginForm $direction="column" $gap="12px">
           <div>
             <C.InputBox
-              justify="space-between"
-              align="center"
+              $justify="space-between"
+              $align="center"
               $isValidValue={isValidEmail(email)}
               $isEmpty={email === ""}
             >
@@ -77,6 +85,8 @@ export default function LoginForms() {
                 value={email}
                 onChange={handleEmailChange}
                 onFocus={handleEmailFocus}
+                onKeyDown={handleKeyDown} // 엔터 키 핸들링
+                tabIndex={1} // 탭 순서
                 placeholder="이메일"
               />
               {email && (
@@ -91,8 +101,8 @@ export default function LoginForms() {
           </div>
           <div>
             <C.InputBox
-              justify="space-between"
-              align="center"
+              $justify="space-between"
+              $align="center"
               $isValidValue={false}
               $isEmpty={true}
             >
@@ -101,6 +111,8 @@ export default function LoginForms() {
                 value={password}
                 onChange={handlePasswordChange}
                 onFocus={handlePasswordFocus}
+                onKeyDown={handleKeyDown} // 엔터 키 핸들링
+                tabIndex={2} // 탭 순서
                 placeholder="비밀번호 입력"
               />
               <div>
@@ -117,7 +129,7 @@ export default function LoginForms() {
             {/* <C.CautionText>로그인 정보가 틀립니다.</C.CautionText> */}
           </div>
         </S.LoginForm>
-        <S.LoginFormNav justify="space-between" align="center">
+        <S.LoginFormNav $justify="space-between" $align="center">
           <p>
             <input
               type="checkbox"
@@ -144,14 +156,15 @@ export default function LoginForms() {
           $height="medium"
           disabled={!isValidEmail(email) || !password}
           style={{ marginBottom: "48px" }}
+          tabIndex={3} // 탭 순서
         >
           로그인
         </C.SubmitButton>
       </S.LoginFormBox>
       <C.Devider />
-      <S.LoginSNSBox direction="column" align="center" gap="12px">
+      <S.LoginSNSBox $direction="column" $align="center" $gap="12px">
         <p>간편하게 회원가입 및 로그인하기</p>
-        <S.LoginSNSNav gap="18px">
+        <S.LoginSNSNav $gap="18px">
           <Link to="">
             <I.Google />
           </Link>

--- a/src/page/Projects/ProjectsMake.tsx
+++ b/src/page/Projects/ProjectsMake.tsx
@@ -29,7 +29,7 @@ export default function ProjectsMake() {
   // };
 
   return (
-    <S.ProjectsMekeLayout direction="column">
+    <S.ProjectsMekeLayout $direction="column">
       <div>
         <h1>프로젝트 생성하기</h1>
         <p>협업하고 싶은 프로젝트를 모잉과 함께 간단히 생성해보아요!</p>
@@ -60,12 +60,12 @@ export default function ProjectsMake() {
             <C.CautionText>이메일 주소 형식으로 입력해주세요.</C.CautionText>
           )}
         </C.InputWithP> */}
-        <S.ProjectsMekeFormBoxRow gap="16px">
+        <S.ProjectsMekeFormBoxRow $gap="16px">
           <C.InputWithP>
             <p>프로젝트 이름</p>
             <C.InputBox
-              justify="space-between"
-              align="center"
+              $justify="space-between"
+              $align="center"
               $isValidValue={!isValidName(name)}
               $isEmpty={name === ""}
             >
@@ -89,7 +89,7 @@ export default function ProjectsMake() {
           </C.InputWithP>
           <C.InputWithP>
             <p>이메일</p>
-            <C.InputBox justify="space-between" align="center">
+            <C.InputBox $justify="space-between" $align="center">
               <input type="email" placeholder="이메일 주소 입력" />
               {/* {email && (
               <button onClick={clearEmail}>
@@ -102,7 +102,7 @@ export default function ProjectsMake() {
           )} */}
           </C.InputWithP>
         </S.ProjectsMekeFormBoxRow>
-        <S.ProjectsMekeFormBoxRow gap="16px">
+        <S.ProjectsMekeFormBoxRow $gap="16px">
           <C.InputWithP>
             <p>모집 인원</p>
             {/* <C.InputBox
@@ -127,7 +127,7 @@ export default function ProjectsMake() {
           </C.InputWithP>
           <C.InputWithP>
             <p>이메일</p>
-            <C.InputBox justify="space-between" align="center">
+            <C.InputBox $justify="space-between" $align="center">
               <input type="email" placeholder="이메일 주소 입력" />
               {/* {email && (
               <button onClick={clearEmail}>

--- a/src/page/SignIn/SignInDone.tsx
+++ b/src/page/SignIn/SignInDone.tsx
@@ -6,7 +6,7 @@ import { Link } from "react-router-dom";
 
 export default function SignInDone() {
   return (
-    <S.SignInLayout direction="column" align="center">
+    <S.SignInLayout $direction="column" $align="center">
       <div>
         <h1>
           <span>모잉</span>에 가입이 완료되었습니다! 🎉

--- a/src/styledComponents/Flexbox.ts
+++ b/src/styledComponents/Flexbox.ts
@@ -1,18 +1,18 @@
 import styled from "styled-components";
 
 export interface FlexContainerProps {
-  direction?: string;
-  justify?: string;
-  align?: string;
-  gap?: string;
+  $direction?: string;
+  $justify?: string;
+  $align?: string;
+  $gap?: string;
 }
 
 const FlexContainer = styled.div<FlexContainerProps>`
   display: flex;
-  flex-direction: ${(props) => props.direction || "row"};
-  justify-content: ${(props) => props.justify || "flex-start"};
-  align-items: ${(props) => props.align || "stretch"};
-  gap: ${(props) => props.gap || 0};
+  flex-direction: ${(props) => props.$direction || "row"};
+  justify-content: ${(props) => props.$justify || "flex-start"};
+  align-items: ${(props) => props.$align || "stretch"};
+  gap: ${(props) => props.$gap || 0};
 `;
 
 export default FlexContainer;

--- a/src/styledComponents/commonStyle.ts
+++ b/src/styledComponents/commonStyle.ts
@@ -5,9 +5,10 @@ import { ButtonProps } from "./types/ButtonType";
 import { AuthProps } from "./types/AuthType";
 
 export const MarginLayout = styled.div`
-  width: 1200px;
+  display: flex;
+  justify-content: center;
+  min-width: 1200px;
   padding: 0 32px;
-  margin: 0 auto;
 `;
 
 export const Devider = styled.div`


### PR DESCRIPTION
#1 flexbox type, props에 $추가
#2 input 폼 태그에서 엔터 시 바로 전송되는 기능 추가
#3 탭 시 버튼이 아닌 다음 input, 버튼으로 넘어가도록 tabindex 추가

- 로그인에는 이메일 비밀번호 제출버튼 순서 지정
- 회원가입에는 remove, hide/visible 버튼만 순서 제외

#4 onBlur 시 이메일/닉네임 중복확인 구현